### PR TITLE
Excelversionparsing

### DIFF
--- a/Source/ExcelAddInDeploy/Product.wxs
+++ b/Source/ExcelAddInDeploy/Product.wxs
@@ -73,7 +73,10 @@
       <UIRef Id="WixUI_Minimal"/>
     </UI>
     <Property Id="ARPPRODUCTICON" Value="Icon.ico"></Property>
+
+
     <!--IMPORTANT ALL MS OFFICE SUPPORTED VERSIONS ARE HERE: Office 2003, 2007, 2010, 2013 Keep it uptodate-->
+    <!-- these numbers will be parsed individually in the custom actions with InvariantCulture and NumberStyles.Any -->
     <Property Id="OFFICEREGKEYS" Value="11.0,12.0,14.0,15.0" />
     <Property Id="XLL32" Value="ExcelXLL32Packed.xll" />
     <Property Id="XLL64" Value="ExcelXLL64Packed.xll" />

--- a/Source/InstallerCA/CustomAction.cs
+++ b/Source/InstallerCA/CustomAction.cs
@@ -40,7 +40,7 @@ namespace InstallerCA
 
                     foreach (string szOfficeVersionKey in lstVersions)
                     {
-                        nVersion = double.TryParse(szOfficeVersionKey, out nVersion) ? nVersion : 0;
+                        nVersion = double.Parse(szOfficeVersionKey, NumberStyles.Any, CultureInfo.InvariantCulture);
 
                         session.Log("Retrieving Registry Information for : " + szBaseAddInKey + szOfficeVersionKey);
 
@@ -156,7 +156,7 @@ namespace InstallerCA
 
                     foreach (string szOfficeVersionKey in lstVersions)
                     {
-                        nVersion = double.TryParse(szOfficeVersionKey, out nVersion) ? nVersion : 0;
+                        nVersion = double.Parse(szOfficeVersionKey, NumberStyles.Any, CultureInfo.InvariantCulture);
                         szXllToUnRegister = GetAddInName(szXll32Bit, szXll64Bit, szOfficeVersionKey, nVersion);
 
                         // only remove keys where office version is found


### PR DESCRIPTION
I had troubles while parsing the excel version with a non US machine (missing an invariant culture). I also believe that the install should fail if the number cannot be parsed correctly. Indeed there is potentially a mismatch with the installed .xll in the registry. To this aim, I replaced the TryParse by a Parse
