### PR TITLE
Changed GetAddInName() when searching for Bitness of Office 14+ to account for 64bit OSs

### DIFF
--- a/Source/InstallerCA/CustomAction.cs
+++ b/Source/InstallerCA/CustomAction.cs
@@ -54,7 +54,7 @@ namespace InstallerCA
 
                             RegistryKey rkExcelXll = Registry.CurrentUser.OpenSubKey(szKeyName, true);
 
-                            if (rkExcelXll != null)
+                            if (szXllToRegister != string.Empty && rkExcelXll != null)
                             {
                                 string[] szValueNames = rkExcelXll.GetValueNames();
                                 bool bIsOpen = false;
@@ -241,7 +241,10 @@ namespace InstallerCA
             if (nVersion >= 14)
             {
                 // determine if office is 32-bit or 64-bit
-                RegistryKey rkBitness = Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\Office\" + szOfficeVersionKey + @"\Outlook", false);
+            	RegistryKey localMachineRegistry = // 64bit machines need to determine correct hive.
+            		RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, 
+                        Environment.Is64BitOperatingSystem ? RegistryView.Registry64 : RegistryView.Registry32);
+                RegistryKey rkBitness = localMachineRegistry.OpenSubKey(@"Software\Microsoft\Office\" + szOfficeVersionKey + @"\Outlook", false);
                 if (rkBitness != null)
                 {
                     object oBitValue = rkBitness.GetValue("Bitness");


### PR DESCRIPTION
Added logic to look at correct hive on 64bit machines for determining Office 2010+ Bitness.  Also ignore Office version if Bitness not found.

In GetAddInName() I was coming up with NULL for the RegistryKey [rkBitness], thus returning [string.Empty].  I found this was due to my 'SOFTWARE\Microsoft\Office\14.0\Outlook' key hiding in the Wow6432Node branch.  Determining the correct base key fixed this problem for me.

OS: Win 7 Ultimate (64bit)
Office: 2010 (32bit) - without Outlook installed.
