### PR TITLE
fix registration with Win7 64bit and Office 2013 32bit

### DIFF
--- a/Source/InstallerCA/CustomAction.cs
+++ b/Source/InstallerCA/CustomAction.cs
@@ -264,6 +264,10 @@ namespace InstallerCA
                         szXllToRegister = szXll32Name;
                     }
                 }
+                else
+                {
+                    szXllToRegister = szXll32Name;
+                }
             }
             else
             {


### PR DESCRIPTION
Hi,

I ran into a problem registering an add-in on Windows 7 with a 32bit Office 2013. It basically fell through one of the conditions introduced by the last commit.

Best,
Marc
