### PR TITLE
Update To CustomAction.cs to check the 32 bit registry on 64 bit machine...

### DIFF
--- a/Source/InstallerCA/CustomAction.cs
+++ b/Source/InstallerCA/CustomAction.cs
@@ -266,7 +266,39 @@ namespace InstallerCA
                 }
                 else
                 {
-                    szXllToRegister = szXll32Name;
+                    if (Environment.Is64BitOperatingSystem)
+                    {
+                        localMachineRegistry = //64bit machines need to check 32bit registry too!
+                            RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32);
+                        rkBitness =
+                            localMachineRegistry.OpenSubKey(
+                                @"Software\Microsoft\Office\" + szOfficeVersionKey + @"\Outlook", false);
+                        if (rkBitness != null)
+                        {
+                            var oBitValue = rkBitness.GetValue("Bitness");
+                            if (oBitValue != null)
+                            {
+                                if (oBitValue.ToString() == "x64")
+                                {
+                                    szXllToRegister = szXll64Name;
+                                }
+                                else
+                                {
+                                    szXllToRegister = szXll32Name;
+                                }
+                            }
+                            else
+                            {
+                                szXllToRegister = szXll32Name;
+                            }
+                        }
+                        else
+                        {
+                            szXllToRegister = szXll32Name;
+                        }
+                    }
+                    else
+                        szXllToRegister = szXll32Name;
                 }
             }
             else


### PR DESCRIPTION
...s.  Installing Excel 64 bit on a 64 bit machine without installing Outlook leads to no Outlook/Bitness key in the 64 bit registry - but there is one in the 32 bit registry.  For further commentary on this, see: http://stackoverflow.com/questions/2203980/detect-whether-office-2010-is-32bit-or-64bit-via-the-registry
