### PR TITLE
Add values defined in the `Property` elements of `Product.wxs` for log

### DIFF
--- a/Source/InstallerCA/CustomAction.cs
+++ b/Source/InstallerCA/CustomAction.cs
@@ -36,6 +36,7 @@ namespace InstallerCA
                 szXll32Bit = session["XLL32"];
                 szXll64Bit = session["XLL64"];
                 szFolder = session["AddinFolder"];
+                session.Log($"CaRegisterAddIn Args: OFFICEREGKEYS={szOfficeRegKeyVersions}, XLL32={szXll32Bit}, XLL64={szXll64Bit}, szFolder={szFolder}");
 
                 szXll32Bit = szFolder.ToString() + szXll32Bit.ToString();
                 szXll64Bit = szFolder.ToString() + szXll64Bit.ToString();
@@ -157,6 +158,7 @@ namespace InstallerCA
                 szXll32Bit = session["XLL32"];
                 szXll64Bit = session["XLL64"];
                 szFolder = session["AddinFolder"];
+                session.Log($"CaUnRegisterAddIn Args: OFFICEREGKEYS={szOfficeRegKeyVersions}, XLL32={szXll32Bit}, XLL64={szXll64Bit}, szFolder={szFolder}");
 
                 szXll32Bit = szFolder.ToString() + szXll32Bit.ToString();
                 szXll64Bit = szFolder.ToString() + szXll64Bit.ToString();


### PR DESCRIPTION
Hello maintainers,
 I've been using this template for a while now and I really appreciate the work you've put into it. 
Including values defined in the `Property` elements of `Product.wxs` in the logs is helpful when debugging an installer.